### PR TITLE
Security: Specify loaders for yaml.load()

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,3 +2,4 @@ v1.0.0, 2018-09-21 -- Initial release: A merge of yaml-redirects, yaml-deleted-p
 v1.0.1, 2018-10-05 -- Support empty YAML files
 v1.0.2, 2018-10-08 -- Handle extra arguments from views in Django without erroring
 v1.1.0, 2018-10-09 -- Rename django->django_helpers flask->flask_helpers modules to avoid namespace clashes
+v1.1.1, 2019-03-30 -- Security: Always specify loaders when using yaml.load()

--- a/canonicalwebteam/yaml_responses/django_helpers.py
+++ b/canonicalwebteam/yaml_responses/django_helpers.py
@@ -5,6 +5,7 @@ import os
 import yaml
 from django.shortcuts import redirect, render
 from django.conf.urls import url
+from yamlloader import ordereddict
 
 
 def _create_view(view_callback, url_mapping, settings={}):
@@ -36,7 +37,9 @@ def _create_views_from_yaml(yaml_filepath, view_callback, settings={}):
 
     if os.path.isfile(yaml_filepath):
         with open(yaml_filepath) as yaml_paths_file:
-            url_paths = yaml.load(yaml_paths_file.read())
+            url_paths = yaml.load(
+                yaml_paths_file.read(), Loader=ordereddict.CLoader
+            )
             if url_paths:
                 for url_path, url_mapping in url_paths.items():
                     urlpatterns.append(

--- a/canonicalwebteam/yaml_responses/flask_helpers.py
+++ b/canonicalwebteam/yaml_responses/flask_helpers.py
@@ -1,11 +1,11 @@
-# Core
+# Standard library
 import os
 import re
 
-# External
+# Packages
 import flask
 import yaml
-import yamlordereddictloader
+from yamlloader import ordereddict
 
 
 class YamlRegexMap:
@@ -28,9 +28,7 @@ class YamlRegexMap:
 
         if os.path.isfile(filepath):
             with open(filepath) as redirects_file:
-                lines = yaml.load(
-                    redirects_file, Loader=yamlordereddictloader.Loader
-                )
+                lines = yaml.load(redirects_file, Loader=ordereddict.CLoader)
 
                 if lines:
                     for url_match, target_url in lines.items():
@@ -130,7 +128,7 @@ def prepare_deleted(path="deleted.yaml", view_callback=_deleted_callback):
 
     if os.path.isfile(path):
         with open(path) as deleted_file:
-            deleted_urls = yaml.load(deleted_file)
+            deleted_urls = yaml.load(deleted_file, Loader=ordereddict.CLoader)
 
     def _show_deleted():
         """

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="canonicalwebteam.yaml-responses",
-    version="1.1.0",
+    version="1.1.1",
     author="Canonical Webteam",
     url="https://github.com/canonical-webteam/yaml-responses",
     packages=["canonicalwebteam.yaml_responses"],
@@ -12,11 +12,8 @@ setup(
         "Functions to read from yaml files to provide"
         "generic responses to URLs in Django and Flask"
     ),
-    install_requires=["pyyaml"],
-    extras_require={
-        "django": ["Django"],
-        "flask": ["flask", "yamlordereddictloader"],
-    },
-    tests_require=["Django", "flask", "yamlordereddictloader"],
+    install_requires=["pyyaml", "yamlloader"],
+    extras_require={"django": ["Django"], "flask": ["flask"]},
+    tests_require=["Django", "flask", "pyyaml", "yamlloader"],
     test_suite="tests",
 )


### PR DESCRIPTION
Currently, this message is appearing in any project using this module:

> YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.

This fixes that warning.

QA
--

Check tests pass.